### PR TITLE
Feature 1.15: Setting up CORS between Netlify and Heroku

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,4 @@
+export const API_URL =
+  process.env.NODE_ENV === 'development'
+    ? '/cohorts'
+    : 'https://cohort-9-data-viz.herokuapp.com/cohorts';

--- a/src/store/actions/cohorts.actions.js
+++ b/src/store/actions/cohorts.actions.js
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { COHORTS } from './actions.type';
+import { API_URL } from '../../constants';
 
 export const setCohortsData = (cohorts = {}) => ({
   type: COHORTS.SET_DATA,
@@ -9,6 +10,6 @@ export const setCohortsData = (cohorts = {}) => ({
 export const fetchCohortsThunk = () => dispatch => {
   // TODO: Add error handling
   return axios
-    .get('/cohorts')
+    .get(API_URL)
     .then(res => dispatch(setCohortsData(res.data.data)));
 };


### PR DESCRIPTION
* changed API URL to be a constant
* API URL is /cohorts if running app locally or https://cohort-9-data-viz.herokuapp.com/cohorts if app is running on production/Netlify